### PR TITLE
Use location.replace instead of location.hash. 

### DIFF
--- a/server/static/leafletmap.js
+++ b/server/static/leafletmap.js
@@ -4,8 +4,9 @@ var Hashing = (function() {
 
   function setHash(zoom, lat, lng) {
     var precision = Math.max(0, Math.ceil(Math.log(zoom) / Math.LN2));
-    location.hash = '#' + zoom.toFixed(2) + '/' +
+    hash = '#' + zoom.toFixed(2) + '/' +
                     lat.toFixed(precision) + '/' + lng.toFixed(precision);
+    location.replace(hash);
   }
 
   return {


### PR DESCRIPTION
It does not create history entry for every image drag.
